### PR TITLE
Remove conflicting license section

### DIFF
--- a/spec/2020-11-15-asert.md
+++ b/spec/2020-11-15-asert.md
@@ -415,9 +415,3 @@ valuable suggestions for improvement:
 [14] <http://toom.im/bch/aserti3_approx_error.html>
 
 [15] <https://github.com/zawy12/difficulty-algorithms/issues/62#issuecomment-646187957>
-
-
-## License
-
-This specification is dual-licensed under the Creative Commons CC0 1.0 Universal and
-GNU All-Permissive licenses.


### PR DESCRIPTION
The MIT license is already provided at the top level of this repository.  There's no reason to introduce additional permissive licenses on this spec since the MIT license is sufficiently permissive for anyone to copy, distribute, or otherwise.